### PR TITLE
Simplify config

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,25 +6,6 @@
 $ npm install --save-dev eslint arundo/eslint-config-arundo
 ```
 
-## Usage
-
-Add some ESLint config to your `package.json`:
-
-```json
-{
-    "devDependencies": {
-        "eslint": "^2.7.0",
-        "eslint-config-arundo": "^0.5.0"
-    },
-    "eslintConfig": {
-        "extends": "arundo"
-    }
-}
-```
-
-Then lint with `$ npm run lint`.
-
-
 ## License
 
 Apache-2 © Arundo

--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 
 ## Install
 
+Since this package is not hosted at NPM, be sure to specify an explicit version tag to prevent major breakage.
+
 ```
-$ npm install --save-dev eslint arundo/eslint-config-arundo
+$ npm install --save-dev arundo/eslint-config-arundo#v3.0.0
 ```
 
 ## License

--- a/index.js
+++ b/index.js
@@ -15,17 +15,6 @@
 */
 
 module.exports = {
-    "env":{
-        "node": true,
-        "mocha": true
-    },
-    "parser": "babel-eslint",
-    "parserOptions": {
-        "ecmaVersion": 7,
-        "ecmaFeatures": {
-            "jsx": true
-        }
-    },
     extends: [ 'airbnb'],
     rules: {
         "indent": [ 2, 2, { "SwitchCase": 1} ],

--- a/index.js
+++ b/index.js
@@ -15,10 +15,10 @@
 */
 
 module.exports = {
-    rules: {
-        "indent": [ 2, 2, { "SwitchCase": 1} ],
-        "space-before-blocks": [2, "never"],
-        "max-len": [1, 120, 4]
-    },
   extends: ['airbnb-base'],
+  rules: {
+    "indent": [ 2, 2, { "SwitchCase": 1} ],
+    "space-before-blocks": [2, "never"],
+    "max-len": [1, 120, 4]
+  },
 };

--- a/index.js
+++ b/index.js
@@ -21,15 +21,4 @@ module.exports = {
         "space-before-blocks": [2, "never"],
         "max-len": [1, 120, 4]
     },
-    settings: {
-        'import/resolver': {
-            node: {
-                extensions: ['.js', '.jsx', '.json'],
-            },
-        },
-        react: {
-            pragma: 'React',
-            version: '15',
-        },
-    },
 };

--- a/index.js
+++ b/index.js
@@ -15,10 +15,10 @@
 */
 
 module.exports = {
-    extends: [ 'airbnb'],
     rules: {
         "indent": [ 2, 2, { "SwitchCase": 1} ],
         "space-before-blocks": [2, "never"],
         "max-len": [1, 120, 4]
     },
+  extends: ['airbnb-base'],
 };

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
   },
   "homepage": "https://github.com/arundo/eslint-config-arundo#readme",
   "peerDependencies": {
-    "eslint": "3.7.1",
-    "eslint-plugin-import": "1.16.0",
-    "eslint-plugin-jsx-a11y": "2.2.2",
+    "eslint": "^3",
+    "eslint-plugin-import": "^2",
+    "eslint-plugin-jsx-a11y": "^2"
   },
   "dependencies": {
     "eslint-config-airbnb-base": "^11"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "eslint-plugin-jsx-a11y": "2.2.2",
   },
   "dependencies": {
-    "eslint-config-airbnb": "12.0.0",
-    "eslint-config-airbnb-base": "8.0.0"
+    "eslint-config-airbnb-base": "^11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-arundo",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "> ESLint [shareable config](http://eslint.org/docs/developer-guide/shareable-configs.html) for [Arundo](http://arundo.com)",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "eslint": "3.7.1",
     "eslint-plugin-import": "1.16.0",
     "eslint-plugin-jsx-a11y": "2.2.2",
-    "eslint-plugin-react": "6.3.0"
   },
   "dependencies": {
     "eslint-config-airbnb": "12.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "eslint-plugin-react": "6.3.0"
   },
   "dependencies": {
-    "babel-eslint": "7.0.0",
     "eslint-config-airbnb": "12.0.0",
     "eslint-config-airbnb-base": "8.0.0"
   }


### PR DESCRIPTION
In an effort to reduce churn across product repos, this PR removes `babel-eslint` and `eslint-plugin-react` dependencies from this config. It also updates the rule sets to only depend on `airbnb/eslint-config-airbnb-base`, which has been factored out to only include JS rules. The previously implemented `airbnb/eslint-config-airbnb` contains extra plugin dependencies such as `eslint-plugin-react`, which should not be treated as a peer requirement for all of Arundo's JS repos that want to take advantage of this lint config.