### PR TITLE
Remove jsx a11y peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-arundo",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "> ESLint [shareable config](http://eslint.org/docs/developer-guide/shareable-configs.html) for [Arundo](http://arundo.com)",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "peerDependencies": {
     "eslint": "^3",
     "eslint-plugin-import": "^2",
-    "eslint-plugin-jsx-a11y": "^2"
   },
   "dependencies": {
     "eslint-config-airbnb-base": "^11"


### PR DESCRIPTION
This removes the warning about the JSX peer dependency from packages that do not implement jsx.