### PR TITLE
Version Bump for NPM deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-arundo",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "> ESLint [shareable config](http://eslint.org/docs/developer-guide/shareable-configs.html) for [Arundo](http://arundo.com)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Due git tagging and NPM versioning, the previous version number cannot be used in NPM.