### PR TITLE
Extraneous modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,6 @@ module.exports = {
     "space-before-blocks": [2, "never"],
     "max-len": [1, 120, 4],
     "comma-dangle": [2, 'always-multiline'],
-    "import/no-extraneous-dependencies": 0,
+    "import/no-extraneous-dependencies": [2, { }],
   },
 };

--- a/index.js
+++ b/index.js
@@ -21,5 +21,6 @@ module.exports = {
     "space-before-blocks": [2, "never"],
     "max-len": [1, 120, 4],
     "comma-dangle": [2, 'always-multiline'],
+    "import/no-extraneous-dependencies": 0,
   },
 };


### PR DESCRIPTION
Prevents the following error from occurring when importing libraries into unit tests.

```
/file.spec.js
  2:1  error  'chai' should be listed in the project's dependencies, not devDependencies  import/no-extraneous-dependencies
```

Documentation for this rule is here: https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-extraneous-dependencies.md. This cannot be applied if we expect to use testing dependencies in test files.